### PR TITLE
Declare 3.20 compatible

### DIFF
--- a/maximus-two@wilfinitlike.gmail.com/metadata.json
+++ b/maximus-two@wilfinitlike.gmail.com/metadata.json
@@ -4,7 +4,8 @@
   "name": "Maximus Two",
   "shell-version": [
     "3.16",
-    "3.18"
+    "3.18",
+    "3.20"
   ],
   "url": "https://github.com/wilfm/GnomeExtensionMaximusTwo",
   "uuid": "maximus-two@wilfinitlike.gmail.com",


### PR DESCRIPTION
The extension seems to be compatible without any change. It is not my own fork, but I tested and found it working flawlessly. As you already maintain [the window buttons extension](https://github.com/mathematicalcoffee/Gnome-Shell-Window-Buttons-Extension) which also stems from a related extension by [mathematicalcoffe](https://github.com/mathematicalcoffee), I percieve you as the new maintainer of [wilfm's inactive fork](https://github.com/wilfm/GnomeExtensionMaximusTwo) and request merge here.
