### PR TITLE
bump version

### DIFF
--- a/maximus-two@wilfinitlike.gmail.com/metadata.json
+++ b/maximus-two@wilfinitlike.gmail.com/metadata.json
@@ -11,5 +11,5 @@
   ],
   "url": "https://github.com/wilfm/GnomeExtensionMaximusTwo",
   "uuid": "maximus-two@wilfinitlike.gmail.com",
-  "version": 5
+  "version": 6
 }


### PR DESCRIPTION
I suggest the recent compatibility updates and fixes (from pull requests #2 and #3) should not only be uploaded via extensions.gnome.org, but also bump the version number. This would cause distribution packages tracking the extension, like [the one I maintain](https://aur.archlinux.org/packages/gnome-shell-extension-maximus-two-git/), to issue an update. Adding [a release on GitHub](https://github.com/danielkza/GnomeExtensionMaximusTwo/releases) would also be useful.